### PR TITLE
[ENT-1492] Add ability to publish jpegs with ZV2 metadata

### DIFF
--- a/ros2/Dockerfile
+++ b/ros2/Dockerfile
@@ -27,10 +27,22 @@ RUN apt-get update && \
         clang-14 \
         clang++-14 \
         libc++-14-dev \
-        libc++abi-14-dev && \
+        libc++abi-14-dev \
+        libexiv2-dev && \
     echo 'source /opt/ros/$ROS_DISTRO/setup.bash' >> ~/.bashrc &&\
     rm -rf /var/lib/apt/lists/* &&\
     apt-get clean
+
+RUN cd ${ROS_USER_HOME} && \
+    git clone --depth 1 --branch 10.1.1 https://github.com/fmtlib/fmt.git && \
+    cd fmt && \
+    mkdir build && \
+    cd build && \
+    cmake -DFMT_TEST=FALSE -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE .. && \
+    make && \
+    make install && \
+    cd ${ROS_USER_HOME} && \
+    rm -Rf fmt
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
@@ -50,7 +62,7 @@ WORKDIR ${ROS_USER_HOME}/AirSim/ros2
 
 SHELL ["/bin/bash", "-c"]
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --symlink-install --event-handlers console_direct+
+    colcon build --symlink-install --event-handlers console_cohesion+
 
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ${ROS_USER_HOME}/.bashrc
 RUN echo "source ${ROS_USER_HOME}/AirSim/ros2/install/setup.bash" >> ${ROS_USER_HOME}/.bashrc

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -22,3 +22,14 @@ Alternatively:
 ```
 ./run.sh -b
 ```
+
+## ZV2 metadata
+To publish jpegs with ZV2 metadata:
+```
+./run.sh -z
+```
+
+Alternatively:
+```
+./run.sh --zv2_metadata
+```

--- a/ros2/entrypoint.sh
+++ b/ros2/entrypoint.sh
@@ -1,4 +1,10 @@
-source /opt/ros/galactic/setup.bash
-source /home/ros/AirSim/ros2/install/setup.bash
+source /opt/ros/iron/setup.bash
+source /home/ros/AirSim/ros2/install/local_setup.bash
 
-ros2 launch airsim_ros_pkgs airsim_node.launch.py
+ROS2_LAUNCH_COMMAND=(ros2 launch airsim_ros_pkgs airsim_node.launch.py)
+
+if [ "${1}" == "zv2_metadata" ]; then
+    ROS2_LAUNCH_COMMAND+=("zv2_metadata:=True")
+fi
+
+${ROS2_LAUNCH_COMMAND[@]}

--- a/ros2/src/airsim_ros_pkgs/CMakeLists.txt
+++ b/ros2/src/airsim_ros_pkgs/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_default_runtime REQUIRED)
 find_package(airsim_interfaces REQUIRED)
 find_package(OpenCV REQUIRED)
+find_package(exiv2 REQUIRED CONFIG NAMES exiv2)
+find_package(fmt REQUIRED)
 
 set(AIRSIM_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../)
 
@@ -50,7 +52,7 @@ set(INCLUDE_DIRS include
 include_directories(${INCLUDE_DIRS})
 
 add_library(airsim_settings_parser src/airsim_settings_parser.cpp)
-target_link_libraries(airsim_settings_parser AirLib)
+target_link_libraries(airsim_settings_parser AirLib exiv2lib)
 
 add_library(pd_position_controller_simple src/pd_position_controller_simple.cpp)
 target_link_libraries(pd_position_controller_simple AirLib)
@@ -67,7 +69,7 @@ ament_target_dependencies(pd_position_controller_simple
 )
 
 add_library(airsim_ros src/airsim_ros_wrapper.cpp)
-target_link_libraries(airsim_ros ${OpenCV_LIBS} yaml-cpp AirLib airsim_settings_parser)
+target_link_libraries(airsim_ros ${OpenCV_LIBS} yaml-cpp AirLib airsim_settings_parser exiv2lib fmt::fmt)
 ament_target_dependencies(airsim_ros 
   rclcpp
   sensor_msgs
@@ -85,7 +87,7 @@ ament_target_dependencies(airsim_ros
 )
 
 add_executable(airsim_node src/airsim_node.cpp)
-target_link_libraries(airsim_node airsim_ros AirLib)
+target_link_libraries(airsim_node airsim_ros AirLib exiv2lib fmt::fmt)
 ament_target_dependencies(airsim_node 
   rclcpp
 )

--- a/ros2/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
+++ b/ros2/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
@@ -41,6 +41,7 @@ STRICT_MODE_OFF //todo what does this do?
 #include <nav_msgs/msg/odometry.hpp>
 #include <opencv2/opencv.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/distortion_models.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/image_encodings.hpp>
@@ -62,6 +63,8 @@ STRICT_MODE_OFF //todo what does this do?
 #include <tf2/convert.h>
 #include <unordered_map>
 #include <memory>
+
+#include <image_metadata.hpp>
 
     struct SimpleMatrix
 {
@@ -237,6 +240,8 @@ private:
 
     std::shared_ptr<sensor_msgs::msg::Image> get_img_msg_from_response(const ImageResponse& img_response, const rclcpp::Time curr_ros_time, const std::string frame_id);
     std::shared_ptr<sensor_msgs::msg::Image> get_depth_img_msg_from_response(const ImageResponse& img_response, const rclcpp::Time curr_ros_time, const std::string frame_id);
+    std::shared_ptr<sensor_msgs::msg::CompressedImage> get_jpeg_msg_from_img_msg(
+        std::shared_ptr<sensor_msgs::msg::Image> image_message);
 
     void process_and_publish_img_response(const std::vector<ImageResponse>& img_response_vec, const int img_response_idx, const std::string& vehicle_name);
 
@@ -353,6 +358,7 @@ private:
     typedef std::pair<std::vector<ImageRequest>, std::string> airsim_img_request_vehicle_name_pair;
     std::vector<airsim_img_request_vehicle_name_pair> airsim_img_request_vehicle_name_pair_vec_;
     std::vector<image_transport::Publisher> image_pub_vec_;
+    std::vector<rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr> jpeg_pub_vec_;
     std::vector<rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr> cam_info_pub_vec_;
 
     typedef std::pair<std::string, msr::airlib::Vector3r> camera_position_name_pair;
@@ -380,4 +386,6 @@ private:
     static constexpr char R_YML_NAME[] = "rectification_matrix";
     static constexpr char P_YML_NAME[] = "projection_matrix";
     static constexpr char DMODEL_YML_NAME[] = "distortion_model";
+
+    bool zv2_metadata_;
 };

--- a/ros2/src/airsim_ros_pkgs/include/image_metadata.hpp
+++ b/ros2/src/airsim_ros_pkgs/include/image_metadata.hpp
@@ -1,0 +1,424 @@
+#ifndef __IMAGE_METADATA__
+#define __IMAGE_METADATA__
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <exiv2/exiv2.hpp>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/chrono.h>
+
+
+namespace image_metadata {
+
+class Metadata {
+public:
+    Metadata()
+        : _rangefinder_distance(0.)
+        , _drone_attitude()
+        , _drone_gps()
+        , _fix_state(0.)
+        , _gimbal_attitude()
+        , _gps_counter(0)
+        , _horizontal_accuracy(0.)
+        , _horizontal_dilution_precision(0.)
+        , _mission_id()
+        , _num_glonass_satellites_used(0)
+        , _num_gps_satellites_used(0)
+        , _num_total_satellites_used(0)
+        , _position_dilution_precision(0.)
+        , _relative_height(0.)
+        , _rtk_connection_status(0)
+        , _rtk_position()
+        , _rtk_position_info(0)
+        , _rtk_velocity()
+        , _rtk_yaw(0)
+        , _rtk_yaw_info(0)
+        , _speed_accuracy(0.)
+        , _time()
+        , _vertical_accuracy(0.)
+    {
+    }
+
+    Metadata(
+        const double rangefinder_distance,
+        const std::vector<float> drone_attitude,
+        const std::vector<float> drone_gps,
+        const float fix_state,
+        const std::vector<float> gimbal_attitude,
+        const short gps_counter,
+        const float horizontal_accuracy,
+        const float horizontal_dilution_precision,
+        const std::string mission_id,
+        const int num_glonass_satellites_used,
+        const int num_gps_satellites_used,
+        const int num_total_satellites_used,
+        const float position_dilution_precision,
+        const float relative_height,
+        const int rtk_connection_status,
+        const std::vector<double> rtk_position,
+        const int rtk_position_info,
+        const std::vector<float> rtk_velocity,
+        const int rtk_yaw,
+        const int rtk_yaw_info,
+        const float speed_accuracy,
+        const std::chrono::system_clock::time_point time,
+        const float vertical_accuracy
+    )
+        : _rangefinder_distance(rangefinder_distance)
+        , _drone_attitude(drone_attitude)
+        , _drone_gps(drone_gps)
+        , _fix_state(fix_state)
+        , _gimbal_attitude(gimbal_attitude)
+        , _gps_counter(gps_counter)
+        , _horizontal_accuracy(horizontal_accuracy)
+        , _horizontal_dilution_precision(horizontal_dilution_precision)
+        , _mission_id(mission_id)
+        , _num_glonass_satellites_used(num_glonass_satellites_used)
+        , _num_gps_satellites_used(num_gps_satellites_used)
+        , _num_total_satellites_used(num_total_satellites_used)
+        , _position_dilution_precision(position_dilution_precision)
+        , _relative_height(relative_height)
+        , _rtk_connection_status(rtk_connection_status)
+        , _rtk_position(rtk_position)
+        , _rtk_position_info(rtk_position_info)
+        , _rtk_velocity(rtk_velocity)
+        , _rtk_yaw(rtk_yaw)
+        , _rtk_yaw_info(rtk_yaw_info)
+        , _speed_accuracy(speed_accuracy)
+        , _time(time)
+        , _vertical_accuracy(vertical_accuracy)
+    {
+    }
+
+    const double& rangefinderDistance() const
+    {
+        return _rangefinder_distance;
+    }
+
+    const float& droneAttitudePitch() const
+    {
+        return _drone_attitude.at(1);
+    }
+
+    const float& droneAttitudeRoll() const
+    {
+        return _drone_attitude.at(0);
+    }
+
+    const float& droneAttitudeYaw() const
+    {
+        return _drone_attitude.at(2);
+    }
+
+    const std::string droneGpsAltitude() const
+    {
+        return double_to_str(static_cast<double>(_drone_gps.at(2)), 6);
+    }
+
+    const std::string droneGpsLatitude() const
+    {
+        return double_to_str(static_cast<double>(_drone_gps.at(0)), 6);
+    }
+
+    const std::string droneGpsLongitude() const
+    {
+        return double_to_str(static_cast<double>(_drone_gps.at(1)), 6);
+    }
+
+    const std::string fixState() const
+    {
+        return double_to_str(static_cast<double>(_fix_state), 6);
+    }
+
+    const std::vector<float>& gimbalAttitude() const
+    {
+        return _gimbal_attitude;
+    }
+
+    const float& gimbalAttitudePitch() const
+    {
+        return _gimbal_attitude.at(1);
+    }
+
+    const float& gimbalAttitudeRoll() const
+    {
+        return _gimbal_attitude.at(0);
+    }
+
+    const float& gimbalAttitudeYaw() const
+    {
+        return _gimbal_attitude.at(2);
+    }
+
+    const short& gpsCounter() const
+    {
+        return _gps_counter;
+    }
+
+    const std::string horizontalAccuracy() const
+    {
+        return double_to_str(static_cast<double>(_horizontal_accuracy), 6);
+    }
+
+    const std::string horizontalDilutionPrecision() const
+    {
+        return double_to_str(static_cast<double>(_horizontal_dilution_precision), 6);
+    }
+
+    const std::string& missionId() const
+    {
+        return _mission_id;
+    }
+
+    const int& numGlonassSatellitesUsed() const
+    {
+        return _num_glonass_satellites_used;
+    }
+
+    const int& numGpsSatellitesUsed() const
+    {
+        return _num_gps_satellites_used;
+    }
+
+    const int& numTotalSatellitesUsed() const
+    {
+        return _num_total_satellites_used;
+    }
+
+    const std::string positionDilutionPrecision() const
+    {
+        return double_to_str(static_cast<double>(_position_dilution_precision), 6);
+    }
+
+    const std::string relativeHeight() const
+    {
+        return double_to_str(static_cast<double>(_relative_height), 6);
+    }
+
+    const int& rtkConnectionStatus() const
+    {
+        return _rtk_connection_status;
+    }
+
+    const std::string rtkPositionAltitude() const
+    {
+        return double_to_str(_rtk_position.at(2), 8);
+    }
+
+    const std::string rtkPositionLatitude() const
+    {
+        return double_to_str(_rtk_position.at(0), 8);
+    }
+
+    const std::string rtkPositionLongitude() const
+    {
+        return double_to_str(_rtk_position.at(1), 8);
+    }
+
+    const int& rtkPositionInfo() const
+    {
+        return _rtk_position_info;
+    }
+
+    const std::string rtkVelocityX() const
+    {
+        return double_to_str(static_cast<double>(_rtk_velocity.at(0)), 6);
+    }
+
+    const std::string rtkVelocityY() const
+    {
+        return double_to_str(static_cast<double>(_rtk_velocity.at(1)), 6);
+    }
+
+    const std::string rtkVelocityZ() const
+    {
+        return double_to_str(static_cast<double>(_rtk_velocity.at(2)), 6);
+    }
+
+    const int& rtkYaw() const
+    {
+        return _rtk_yaw;
+    }
+
+    const int& rtkYawInfo() const
+    {
+        return _rtk_yaw_info;
+    }
+
+    const std::string speedAccuracy() const
+    {
+        return double_to_str(static_cast<double>(_speed_accuracy), 6);
+    }
+
+    const std::chrono::system_clock::time_point& time() const
+    {
+        return _time;
+    }
+
+    const std::string verticalAccuracy() const
+    {
+        return double_to_str(static_cast<double>(_vertical_accuracy), 6);
+    }
+
+private:
+    const double _rangefinder_distance;
+
+    const std::vector<float> _drone_attitude;
+
+    const std::vector<float> _drone_gps;
+
+    const float _fix_state;
+
+    const std::vector<float> _gimbal_attitude;
+
+    const short _gps_counter;
+
+    const float _horizontal_accuracy;
+
+    const float _horizontal_dilution_precision;
+
+    const std::string _mission_id;
+
+    const int _num_glonass_satellites_used;
+
+    const int _num_gps_satellites_used;
+
+    const int _num_total_satellites_used;
+
+    const float _position_dilution_precision;
+
+    const float _relative_height;
+
+    const int _rtk_connection_status;
+
+    const std::vector<double> _rtk_position;
+
+    const int _rtk_position_info;
+
+    const std::vector<float> _rtk_velocity;
+
+    const int _rtk_yaw;
+
+    const int _rtk_yaw_info;
+
+    const float _speed_accuracy;
+
+    const std::chrono::system_clock::time_point _time;
+
+    const float _vertical_accuracy;
+
+    const std::string double_to_str(double value, int precision) const
+    {
+        std::ostringstream stream;
+        stream << std::fixed << std::setprecision(precision) << value;
+        return stream.str();
+    }
+};
+
+class Image {
+public:
+    Image(std::string file_path)
+        : _image(Exiv2::ImageFactory::open(file_path))
+    {
+    }
+
+    Image(const uint8_t* data, std::size_t size)
+        : _image(Exiv2::ImageFactory::open(data, size))
+    {
+    }
+
+    void output(std::vector<uint8_t>& data)
+    {
+        uint8_t* byte_data = _image->io().mmap();
+        size_t size = _image->io().size();
+        data.assign(byte_data, byte_data + size);
+    }
+
+    void update(const Metadata metadata)
+    {
+        _image->readMetadata();
+        updateXmp(metadata);
+        updateExif(metadata);
+
+        // This could throw and should be caught by the consumer.
+        _image->writeMetadata();
+    }
+
+private:
+    Exiv2::Image::AutoPtr _image;
+
+    void updateExif(const Metadata& metadata)
+    {
+        Exiv2::ExifData& exif_data = _image->exifData();
+
+        exif_data["Exif.Photo.SubjectDistance"] =
+            Exiv2::floatToRationalCast(metadata.rangefinderDistance());
+
+        auto metadata_time_point_seconds =
+            std::chrono::time_point_cast<std::chrono::seconds>(metadata.time());
+        exif_data["Exif.Photo.DateTimeOriginal"] =
+            fmt::format("{:%Y:%m:%d %H:%M:%S}", metadata_time_point_seconds);
+        exif_data["Exif.Image.DateTime"] =
+            fmt::format("{:%Y:%m:%d %H:%M:%S}", metadata_time_point_seconds);
+    }
+
+    void updateXmp(const Metadata& metadata)
+    {
+        Exiv2::XmpData& xmp_data = _image->xmpData();
+
+        Exiv2::XmpProperties::registerNs("Zeitview/", "zv");
+
+        xmp_data["Xmp.zv.AutoFlightMeta"] = metadata.missionId();
+
+        xmp_data["Xmp.zv.RangefinderDistance"] = metadata.rangefinderDistance();
+
+        xmp_data["Xmp.zv.AttitudeRoll"] = metadata.droneAttitudeRoll();
+        xmp_data["Xmp.zv.AttitudePitch"] = metadata.droneAttitudePitch();
+        xmp_data["Xmp.zv.AttitudeYaw"] = metadata.droneAttitudeYaw();
+
+        xmp_data["Xmp.zv.GimbalAttitudeRoll"] = metadata.gimbalAttitudeRoll();
+        xmp_data["Xmp.zv.GimbalAttitudePitch"] = metadata.gimbalAttitudePitch();
+        xmp_data["Xmp.zv.GimbalAttitudeYaw"] = metadata.gimbalAttitudeYaw();
+
+        xmp_data["Xmp.zv.RtkLatitude"] = metadata.rtkPositionLatitude();
+        xmp_data["Xmp.zv.RtkLongitude"] = metadata.rtkPositionLongitude();
+        xmp_data["Xmp.zv.RtkAltitude"] = metadata.rtkPositionAltitude();
+
+        xmp_data["Xmp.zv.RtkVelocityX"] = metadata.rtkVelocityX();
+        xmp_data["Xmp.zv.RtkVelocityY"] = metadata.rtkVelocityY();
+        xmp_data["Xmp.zv.RtkVelocityZ"] = metadata.rtkVelocityZ();
+
+        xmp_data["Xmp.zv.RtkYaw"] = metadata.rtkYaw();
+
+        xmp_data["Xmp.zv.RtkYawInfo"] = metadata.rtkYawInfo();
+
+        xmp_data["Xmp.zv.RtkPositionInfo"] = metadata.rtkPositionInfo();
+
+        xmp_data["Xmp.zv.GpsLatitude"] = metadata.droneGpsLatitude();
+        xmp_data["Xmp.zv.GpsLongitude"] = metadata.droneGpsLongitude();
+        xmp_data["Xmp.zv.GpsAltitude"] = metadata.droneGpsAltitude();
+
+        xmp_data["Xmp.zv.RelativeHeight"] = metadata.relativeHeight();
+
+        xmp_data["Xmp.zv.RtkConnectionStatus"] = metadata.rtkConnectionStatus();
+        
+        xmp_data["Xmp.zv.HorizontalDilutionPrecision"] = metadata.horizontalDilutionPrecision();
+        xmp_data["Xmp.zv.PositionDilutionPrecision"] = metadata.positionDilutionPrecision();
+        xmp_data["Xmp.zv.FixState"] = metadata.fixState();
+        xmp_data["Xmp.zv.VerticalAccuracy"] = metadata.verticalAccuracy();
+        xmp_data["Xmp.zv.HorizontalAccuracy"] = metadata.horizontalAccuracy();
+        xmp_data["Xmp.zv.SpeedAccuracy"] = metadata.speedAccuracy();
+        xmp_data["Xmp.zv.NumGpsSatellitesUsed"] = metadata.numGpsSatellitesUsed();
+        xmp_data["Xmp.zv.NumGlonassSatellitesUsed"] = metadata.numGlonassSatellitesUsed();
+        xmp_data["Xmp.zv.NumTotalSatellitesUsed"] = metadata.numTotalSatellitesUsed();
+        xmp_data["Xmp.zv.GpsCounter"] = metadata.gpsCounter();
+    }
+};
+
+} // namespace image_metadata
+
+#endif // __IMAGE_METADATA__

--- a/ros2/src/airsim_ros_pkgs/launch/airsim_node.launch.py
+++ b/ros2/src/airsim_ros_pkgs/launch/airsim_node.launch.py
@@ -26,6 +26,10 @@ def generate_launch_description():
     host = DeclareLaunchArgument(
         "host",
         default_value='localhost')
+
+    zv2_metadata = DeclareLaunchArgument(
+        "zv2_metadata",
+        default_value="False")
   
     airsim_node = Node(
             package='airsim_ros_pkgs',
@@ -40,8 +44,11 @@ def generate_launch_description():
                 'update_airsim_gimbal_every_n_sec': 0.01,
                 'update_lidar_every_n_sec': 0.01,
                 'publish_clock': LaunchConfiguration('publish_clock'),
-                'host_ip': LaunchConfiguration('host')
-            }])
+                'host_ip': LaunchConfiguration('host'),
+                'zv2_metadata': LaunchConfiguration('zv2_metadata')
+            }],
+            respawn=True,
+            respawn_delay=0)
 
     static_transforms = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
@@ -57,6 +64,7 @@ def generate_launch_description():
     ld.add_action(publish_clock)
     ld.add_action(is_vulkan)
     ld.add_action(host)
+    ld.add_action(zv2_metadata)
   
     ld.add_action(static_transforms)
     ld.add_action(airsim_node)

--- a/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/airsim_ros_wrapper.cpp
@@ -1384,7 +1384,13 @@ std::shared_ptr<sensor_msgs::msg::CompressedImage> AirsimROSWrapper::get_jpeg_ms
         if (cv::imencode(".jpg", cv_ptr->image, jpeg_message->data, params)) {
             image_metadata::Image image(jpeg_message->data.data(), jpeg_message->data.size());
             image_metadata::Metadata metadata{0.1, {1, 2, 3}, {1,2,3}, 0.1, {1,2,3}, 0, 0.1, 0.1, "mission", 14, 10, 20, 0.1, 10.1, 20, {1,2,3}, 40, {1,2,3}, 10, 20, 0.1, std::chrono::system_clock::now(), 0.1};
-            image.update(metadata);
+
+            try {
+                image.update(metadata);
+            } catch (const Exiv2::Error& exception) {
+                RCLCPP_ERROR(nh_->get_logger(), "Exiv2 image metadata update failed: %s", exception.what());
+            }
+
             image.output(jpeg_message->data);
         } else {
             RCLCPP_ERROR(nh_->get_logger(), "cv::imencode conversion to jpeg failed");


### PR DESCRIPTION
Here's how to test and validate that metadata is in the published jpegs.

First, run ardupilot_sitl and the Airsim ROS 2 node and record a bag (note: be sure to run the Airsim ROS 2 node with the ZV2 metadata mode enabled: `./run.sh -z`):
```
ros2 bag record -a
```

Install dependencies:
```
sudo apt-get install -y python3-venv
```

Create a venv:
```
python3 -m venv zv2_metadata
```

Activate the venv:
```
source zv2_metadata/bin/activate
```

Install python3 dependencies:
```
python3 -m pip install rosbags rosbags-image pyexiv2
```

Create a `zv2_metadata.py` script with the following contents (replace the path to the rosbag):
```
from rosbags.highlevel import AnyReader
from pathlib import Path
import cv2
import pyexiv2

with AnyReader([Path('/path/to/rosbag2_2024_10_30-16_49_21')]) as reader:
    for connection, timestamp, rawdata in reader.messages():
        if connection.topic == '/airsim_node/Copter/front_center_fixed_jpeg/Scene':
            msg = reader.deserialize(rawdata, connection.msgtype)
            img = pyexiv2.ImageData(msg.data.tobytes())
            print(img.read_exif(), img.read_xmp())
```

Then run the script and you should see metadata dumped out for each image frame:
```
python3 zv2_metadata.py
```

Finally, you can deactivate the venv:
```
deactivate
```
